### PR TITLE
Adding basic settings, open Mods folder, and update modsettings.lsx features

### DIFF
--- a/Modthara.Manager/IModManagerSettingsService.cs
+++ b/Modthara.Manager/IModManagerSettingsService.cs
@@ -1,0 +1,15 @@
+
+using System.IO.Abstractions;
+using System.Text.Json;
+
+using static Modthara.Manager.Constants;
+
+namespace Modthara.Manager;
+
+public interface IModManagerSettingsService : IPathProvider
+{
+
+    public Task LoadSettingsAsync();
+
+    public Task SaveSettingsAsync();
+}

--- a/Modthara.Manager/IModSettingsService.cs
+++ b/Modthara.Manager/IModSettingsService.cs
@@ -12,6 +12,8 @@ public interface IModSettingsService
     /// </summary>
     ModSettings ModSettings { get; }
 
+    string Path { get; set; }
+
     /// <summary>
     /// Loads mod settings from a file to <see cref="ModSettings"/>.
     /// </summary>

--- a/Modthara.Manager/IModsService.cs
+++ b/Modthara.Manager/IModsService.cs
@@ -15,6 +15,8 @@ public interface IModsService
     /// <value>An <see cref="IReadOnlyList{ModPackage}"/> containing the mod packages.</value>
     IReadOnlyList<ModPackage> ModPackages { get; }
 
+    string Path { get; set; }
+
     /// <summary>
     /// Loads packages from the specified path to <see cref="ModPackages"/>.
     /// </summary>

--- a/Modthara.Manager/IPathProvider.cs
+++ b/Modthara.Manager/IPathProvider.cs
@@ -1,0 +1,40 @@
+namespace Modthara.Manager;
+
+/// <summary>
+/// Provides general paths.
+/// </summary>
+
+public interface IPathProvider
+{
+    /// <summary>
+    ///     Gets the path of the Mods directory in the Local data files.
+    /// </summary>
+    /// <returns>
+    ///     A path <see cref="string"> to the given directory.
+    /// </returns>
+    string GetModsDirectoryPath();
+
+    /// <summary>
+    ///     Gets the path of the modsettings.lsx file in the player profile data.
+    /// </summary>
+    /// <returns>
+    ///     A path <see cref="string"> to the given file.
+    /// </returns>
+    string GetModSettingsPath();
+
+    /// <summary>
+    ///     Gets the path of the Data directory in the game files.
+    /// </summary>
+    /// <returns>
+    ///     A path <see cref="string"> to the given directory.
+    /// </returns>
+    string GetDataDirectoryPath();
+
+    /// <summary>
+    ///     Gets the path of the bin directory in the game files.
+    /// </summary>
+    /// <returns>
+    ///     A path <see cref="string"> to the given directory.
+    /// </returns>
+    string GetBinDirectoryPath();
+}

--- a/Modthara.Manager/ModManagerSettings.cs
+++ b/Modthara.Manager/ModManagerSettings.cs
@@ -1,0 +1,33 @@
+using System.Text.Json.Serialization;
+
+namespace Modthara.Manager;
+
+[JsonSerializable(typeof(ModManagerSettings))]
+public class ModManagerSettings
+{
+    [JsonRequired]
+    [JsonPropertyName("ModsPath")]
+    public required string _modsPath { get; set; }
+
+    [JsonRequired]
+    [JsonPropertyName("ModsettingsPath")]
+    public required string _modsettingsPath { get; set; }
+
+    [JsonRequired]
+    [JsonPropertyName("BinPath")]
+    public required string _binPath { get; set; }
+
+    [JsonRequired]
+    [JsonPropertyName("DataPath")]
+    public required string _dataPath { get; set; }
+
+    [JsonConstructor]
+    public ModManagerSettings() {}
+    public ModManagerSettings(string ModsPath, string ModsettingsPath, string BinPath, string DataPath)
+    {
+        _modsPath = ModsPath;
+        _modsettingsPath = ModsettingsPath;
+        _binPath = BinPath;
+        _dataPath = DataPath;
+    }
+}

--- a/Modthara.Manager/ModManagerSettingsService.cs
+++ b/Modthara.Manager/ModManagerSettingsService.cs
@@ -1,0 +1,62 @@
+
+using System.IO.Abstractions;
+using System.Text.Json;
+
+using static Modthara.Manager.Constants;
+
+namespace Modthara.Manager;
+
+public class ModManagerSettingsService : IModManagerSettingsService
+{
+    private readonly string _path;
+
+    private readonly IFileSystem _fileSystem;
+
+    private ModManagerSettings? _settings;
+    
+    public ModManagerSettingsService(string path, IFileSystem fs)
+    {
+        _fileSystem = fs;
+        _path = path;
+    }
+
+    public async Task LoadSettingsAsync()
+    {
+        var file = _fileSystem.FileStream.New(_path, FileMode.Open, FileAccess.Read, FileShare.Read,
+            bufferSize: StreamBufferSize, useAsync: true);
+
+        var settings = await JsonSerializer.DeserializeAsync<ModManagerSettings>(file, Constants.JsonSerializerOptions).ConfigureAwait(false);
+        await Task.Run(() => {
+            _settings = settings!;
+            }
+        );
+    }
+
+    public async Task SaveSettingsAsync()
+    {
+        await using var file = _fileSystem.FileStream.New(_path, FileMode.Create, FileAccess.Write, FileShare.Read,
+            bufferSize: StreamBufferSize, useAsync: true);
+
+        await JsonSerializer.SerializeAsync(file, _settings, Constants.JsonSerializerOptions).ConfigureAwait(false);
+    }
+
+    public string GetBinDirectoryPath()
+    {
+        return _settings!._binPath;
+    }
+
+    public string GetDataDirectoryPath()
+    {
+        return _settings!._dataPath;
+    }
+
+    public string GetModsDirectoryPath()
+    {
+        return _settings!._modsPath;
+    }
+
+    public string GetModSettingsPath()
+    {
+        return _settings!._modsettingsPath;
+    }
+}

--- a/Modthara.Manager/ModSettingsService.cs
+++ b/Modthara.Manager/ModSettingsService.cs
@@ -10,11 +10,18 @@ namespace Modthara.Manager;
 /// <inheritdoc />
 public class ModSettingsService : IModSettingsService
 {
-    private readonly string _path;
+    private string _path;
+    public string Path { 
+        get => _path;
+        set {
+            _path = value;
+            ModSettings = null;
+        }
+    }
 
     private readonly IFileSystem _fileSystem;
 
-    public ModSettings ModSettings { get; private set; }
+    public ModSettings? ModSettings { get; private set; }
 
     public ModSettingsService(string path, IFileSystem fileSystem)
     {

--- a/Modthara.Manager/ModsService.cs
+++ b/Modthara.Manager/ModsService.cs
@@ -11,12 +11,19 @@ namespace Modthara.Manager;
 /// <inheritdoc />
 public class ModsService : IModsService
 {
-    private readonly string _path;
+    private string _path;
+    public string Path { 
+        get => _path;
+        set {
+            _path = value;
+            _modPackages = [];
+        }
+    }
 
     private readonly IFileSystem _fileSystem;
     private readonly IModPackageManager _modPackageManager;
 
-    private readonly List<ModPackage> _modPackages = [];
+    private List<ModPackage> _modPackages = [];
 
     public IReadOnlyList<ModPackage> ModPackages => _modPackages;
 

--- a/Modthara.UI/App.axaml.cs
+++ b/Modthara.UI/App.axaml.cs
@@ -67,6 +67,11 @@ public partial class App : Application
             @"\Larian Studios\Baldur's Gate 3\PlayerProfiles\Public\modsettings.lsx",
             s.GetRequiredService<IFileSystem>()));
 
+        services.AddSingleton<IModManagerSettingsService>(s => new ModManagerSettingsService(
+            @"./settings.json",
+            s.GetRequiredService<IFileSystem>()
+        ));
+
         services.AddSingleton<MainViewModel>();
         services.AddSingleton<PackagesViewModel>();
 

--- a/Modthara.UI/ViewModels/ModPackageViewModel.cs
+++ b/Modthara.UI/ViewModels/ModPackageViewModel.cs
@@ -9,7 +9,7 @@ namespace Modthara.UI.ViewModels;
 
 public partial class ModPackageViewModel : ViewModelBase
 {
-    private readonly ModPackage _modPackage;
+    public readonly ModPackage _modPackage;
 
     [ObservableProperty]
     private bool _isEnabled;

--- a/Modthara.UI/ViewModels/PackagesViewModel.cs
+++ b/Modthara.UI/ViewModels/PackagesViewModel.cs
@@ -16,6 +16,8 @@ public partial class PackagesViewModel : ViewModelBase
     private readonly IModsService _modsService;
     private readonly IModSettingsService _modSettingsService;
 
+    private readonly IModManagerSettingsService _modManagerSettingsService;
+
     [ObservableProperty]
     private bool _isViewReady;
 
@@ -186,6 +188,10 @@ public partial class PackagesViewModel : ViewModelBase
 
     public async Task InitializeViewModel()
     {
+        await _modManagerSettingsService.LoadSettingsAsync();
+        _modsService.Path = _modManagerSettingsService.GetModsDirectoryPath();
+        _modSettingsService.Path = _modManagerSettingsService.GetModSettingsPath();
+
         await Task.WhenAll(_modsService.LoadModPackagesAsync(), _modSettingsService.LoadModSettingsAsync());
 
         var (foundOrderMods, missingOrderMods) =

--- a/Modthara.UI/ViewModels/PackagesViewModel.cs
+++ b/Modthara.UI/ViewModels/PackagesViewModel.cs
@@ -1,17 +1,21 @@
 ﻿using System.Collections.ObjectModel;
+using System.Diagnostics;
 
 using Avalonia.Collections;
+using Avalonia.Input.Raw;
+using Avalonia.Interactivity;
 using Avalonia.Threading;
 
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
+using Modthara.Lari;
 using Modthara.Manager;
 using Modthara.UI.Extensions;
 
 namespace Modthara.UI.ViewModels;
 
-public partial class PackagesViewModel : ViewModelBase
+public partial class PackagesViewModelCopy : ViewModelBase
 {
     private readonly IModsService _modsService;
     private readonly IModSettingsService _modSettingsService;
@@ -63,7 +67,24 @@ public partial class PackagesViewModel : ViewModelBase
     [RelayCommand]
     private void OpenModsFolder()
     {
-        throw new NotImplementedException();
+        try {
+            var path = _modManagerSettingsService.GetModsDirectoryPath();
+            var attributes = File.GetAttributes(path);
+            // This check is important, otherwise, a maliciously crafted settings file could
+            // make the following code execute an arbitrary executable.
+            if ((attributes & FileAttributes.Directory) == FileAttributes.Directory) {
+                Process p = new Process();
+                p.StartInfo.UseShellExecute = true;
+                p.StartInfo.FileName = path;
+                p.Start();
+            } else {
+                throw new Exception("ModsPath not a directory"); 
+            }
+            
+        } catch (Exception e)
+        {
+            Console.WriteLine(e.Message);
+        }
     }
 
     [RelayCommand]
@@ -192,7 +213,7 @@ public partial class PackagesViewModel : ViewModelBase
 
         _modSettingsService.SaveModSettingsAsync().Wait();
     }
-    
+
     #endregion
 
     #region Package category
@@ -215,7 +236,7 @@ public partial class PackagesViewModel : ViewModelBase
 
     #endregion
 
-    public PackagesViewModel(
+    public PackagesViewModelCopy(
         IModsService modsService,
         IModSettingsService modSettingsService,
         IModManagerSettingsService modManagerSettingsService)
@@ -224,7 +245,6 @@ public partial class PackagesViewModel : ViewModelBase
         _modSettingsService = modSettingsService;
         _modManagerSettingsService = modManagerSettingsService;
     }
-
 
     public async Task InitializeViewModel()
     {

--- a/Modthara.UI/ViewModels/PackagesViewModel.cs
+++ b/Modthara.UI/ViewModels/PackagesViewModel.cs
@@ -180,11 +180,14 @@ public partial class PackagesViewModel : ViewModelBase
 
     public PackagesViewModel(
         IModsService modsService,
-        IModSettingsService modSettingsService)
+        IModSettingsService modSettingsService,
+        IModManagerSettingsService modManagerSettingsService)
     {
         _modsService = modsService;
         _modSettingsService = modSettingsService;
+        _modManagerSettingsService = modManagerSettingsService;
     }
+
 
     public async Task InitializeViewModel()
     {

--- a/Modthara.UI/ViewModels/PackagesViewModel.cs
+++ b/Modthara.UI/ViewModels/PackagesViewModel.cs
@@ -156,6 +156,43 @@ public partial class PackagesViewModel : ViewModelBase
         }
     }
 
+    [RelayCommand]
+    public void OnUpdateClick()
+    {
+
+        // Remove all mods in mod order to make their order irrelevant
+        foreach (var mod in OrderMods)
+        {
+            if(mod._modPackage.Metadata is not null)
+            {
+                _modSettingsService.ModSettings.Remove(mod._modPackage.Metadata);
+            }
+            
+        }
+
+        // Remove all mods in library to disable mods removed from mod order by the user
+        foreach (var mod in LibraryMods)
+        {
+            if(mod._modPackage.Metadata is not null)
+            {
+                _modSettingsService.ModSettings.Remove(mod._modPackage.Metadata);
+            }
+            
+        }
+
+        // Add back, in sequential order, mods in the mod order
+        foreach (var mod in OrderMods)
+        {
+            if(mod._modPackage.Metadata is not null)
+            {
+                _modSettingsService.ModSettings.Append(mod._modPackage.Metadata);
+            }
+            
+        }
+
+        _modSettingsService.SaveModSettingsAsync().Wait();
+    }
+    
     #endregion
 
     #region Package category

--- a/Modthara.UI/ViewModels/PackagesViewModel.cs
+++ b/Modthara.UI/ViewModels/PackagesViewModel.cs
@@ -15,7 +15,7 @@ using Modthara.UI.Extensions;
 
 namespace Modthara.UI.ViewModels;
 
-public partial class PackagesViewModelCopy : ViewModelBase
+public partial class PackagesViewModel : ViewModelBase
 {
     private readonly IModsService _modsService;
     private readonly IModSettingsService _modSettingsService;
@@ -236,7 +236,7 @@ public partial class PackagesViewModelCopy : ViewModelBase
 
     #endregion
 
-    public PackagesViewModelCopy(
+    public PackagesViewModel(
         IModsService modsService,
         IModSettingsService modSettingsService,
         IModManagerSettingsService modManagerSettingsService)

--- a/Modthara.UI/Views/PackagesView.axaml
+++ b/Modthara.UI/Views/PackagesView.axaml
@@ -47,7 +47,7 @@
                 <Grid RowDefinitions="40, *" Margin="0 0 10 0">
                     <Grid
                         VerticalAlignment="Center"
-                        ColumnDefinitions="Auto 5 * 5 Auto">
+                        ColumnDefinitions="Auto 5 auto 5 * 5 Auto">
 
                         <ComboBox Grid.Column="0"
                                   Classes="Small"
@@ -64,13 +64,19 @@
                             </ComboBox.Items>
                         </ComboBox>
 
-                        <TextBox Grid.Column="2"
+                        <Button Grid.Column="2"
+                                Classes="Small Primary"
+                                Content="Update modsettings.lsx"
+                                Command="{Binding OnUpdateClick}"/>
+                        
+
+                        <TextBox Grid.Column="4"
                                  Watermark="Search..."
                                  Classes="Small clearButton"
                                  Text="{Binding OrderSearchText}"
                                  IsVisible="{Binding OrderSearchVisibility}" />
 
-                        <ToggleButton Grid.Column="4"
+                        <ToggleButton Grid.Column="6"
                                       i:Attached.Icon="fa-solid fa-magnifying-glass"
                                       IsChecked="{Binding OrderSearchVisibility}"
                                       Classes="Small Primary" />


### PR DESCRIPTION
Using an IPathProvider interface so that the settings manager might use multiple providers to possibly provide an "Always prompt" feature, a default provider, with priorities, etc
Long story short, an abstraction to base eventual features on.
The open Mods folder feature is based on this, using the process starting API.
The "update modsettings.lsx" button has a very trivial logic, but should be "ok enough" to not touch unsupported packages.
This PR puts the modmanager to a "usable" state (by that, I mean that I'm using it and it's ok, if a bit finicky in terms of UI).